### PR TITLE
Upgraded protobuf upper bound to protobuf<4.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django>=4.0,<4.1
-protobuf<3.21
+protobuf<4.22
 psycopg2>=2.9
 semver>=2,<3


### PR DESCRIPTION
This matches the versions that will also be used in pulpcore 3.20 and
3.21.