### PR TITLE
Add workaround for .dev version parsing not semver

### DIFF
--- a/pulpanalytics/management/commands/summarize.py
+++ b/pulpanalytics/management/commands/summarize.py
@@ -71,7 +71,11 @@ class Command(BaseCommand):
             xyz_dict = defaultdict(int)
 
             for component in components_qs.filter(name=name):
-                semver_version = semver.parse(component.version)
+                try:
+                    semver_version = semver.parse(component.version)
+                except ValueError:  # Pulp uses x.y.z.dev which is not semver compatible
+                    component.version = component.version.replace('.dev', '-dev')
+                    semver_version = semver.parse(component.version)
                 xy_version = f"{semver_version['major']}.{semver_version['minor']}"
                 xy_dict[xy_version] += 1
                 xyz_dict[component.version] +=1


### PR DESCRIPTION
The strings Pulp uses, e.g. `3.17.2.dev` is not semver parsable, which
causes the semver tools to fail.

See https://github.com/pulp/plugin_template/issues/682 for more info.

This should only be needed in the 'dev' site since Pulp code will only
every submit data with `.dev` at the end to the dev site.