### PR TITLE
Ignore posted data that has unusual verion strings.

### DIFF
--- a/pulpanalytics/views.py
+++ b/pulpanalytics/views.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from contextlib import suppress
+import logging
 
 from django.db import transaction
 from django.http import HttpResponse
@@ -12,9 +13,27 @@ from pulpanalytics.models import Component, DailySummary, OnlineContentApps, Onl
 from pulpanalytics.telemetry_pb2 import Telemetry
 
 
+logger = logging.getLogger(__name__)
+
+
+class LogAndDropData(BaseException):
+    pass
+
+
+def _check_component_version(version):
+    if not version.count('.') == 2:
+        raise LogAndDropData(f"The version string {version} does not have two periods.")
+
+    x, y, z = version.split('.')
+    for item in [x, y, z]:
+        if not item.isdigit():
+            raise LogAndDropData(f"The version string {version} does not only contain numbers.")
+
+
 def _save_components(system, telemetry):
     components = []
     for component in telemetry.components:
+        _check_component_version(component.version)
         components.append(
             Component(system=system, name=component.name, version=component.version)
         )
@@ -153,11 +172,13 @@ class RootView(View):
         telemetry = Telemetry()
         telemetry.ParseFromString(request.body)
 
-        with transaction.atomic():
-            system = System.objects.create(system_id=telemetry.system_id)
-            _save_components(system, telemetry)
-            _save_online_content_apps(system, telemetry)
-            _save_online_workers(system, telemetry)
-
+        try:
+            with transaction.atomic():
+                system = System.objects.create(system_id=telemetry.system_id)
+                _save_components(system, telemetry)
+                _save_online_content_apps(system, telemetry)
+                _save_online_workers(system, telemetry)
+        except LogAndDropData as exc:
+            logger.error(f"Dropping data due a validation error: {exc.args[0]}\n{telemetry}")
 
         return HttpResponse()


### PR DESCRIPTION
This commit should only live on the production site.

Version strings like this will now log as errors and will be dropped:

3.16  # Not enough periods
3.20.a3  # Contains a non-number subcomponent