### PR TITLE
Fix rbac_stats

### DIFF
--- a/pulpanalytics/views.py
+++ b/pulpanalytics/views.py
@@ -237,9 +237,12 @@ def rbac_stats_view(request, measure):
                 while len(dataset) < index:
                     dataset.append(0)
                 dataset.append(item.count)
+        for dataset in counts.values():
+            while len(dataset) <= index:
+                dataset.append(0)
         datasets = [
             {"label": f"<= {key}", "data": counts[key], "fill": "-1"}
-            for key in sorted(counts.keys(), reverse=True)
+            for key in sorted(counts.keys())
         ]
         datasets[0]["fill"] = "origin"
         return JsonResponse({"labels": labels, "datasets": datasets})


### PR DESCRIPTION
* Order of lines should not be reversed, but the lowest number of items in a system should be at the bottom.
* Empty counts need to be filled at the back.